### PR TITLE
Mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # stub-oidc-op 
 
+> **Verify has Closed**
+>
+>This repository is out of date and has been archived
+
 Stub OIDC OP is a very simple stub implementation of an OpenID Connect Provider currently using the Hybrid flow. There is currently no Trust Infrastructure in this implementation and it is very much a work in progress.  
 
 Stub OIDC OP uses Redis to store the authentication code, access token and ID token.


### PR DESCRIPTION
As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.